### PR TITLE
Bug: Fix label line-height.

### DIFF
--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -7,13 +8,53 @@
   <link rel="stylesheet" href="assets/dist/css/app.css">
   <title>Sandbox Environment</title>
 </head>
+
 <body>
-  <h1>Welcome to the sandbox!</h1>
+  <div class="c-wrap">
+    <div class="o-grid">
+      <div class="o-grid__unit o-grid__unit--t-2-3">
+        <h1>Welcome to the sandbox!</h1>
+        <fieldset class="c-fieldset">
+          <label class="c-label" for="firstname">First name:</label>
+          <div class="c-input">
+            <input id="firstname" type="text" required>
+          </div>
+        </fieldset>
+
+        <fieldset class="c-fieldset">
+          <label class="c-label" for="surname">
+            This is a really really really long long label <span class="c-label__tag c-label__tag--optional">optional</span>
+          </label>
+          <span class="c-label__metainfo">With additional help text</span>
+          <div class="c-input">
+            <input id="surname" type="text" required>
+          </div>
+        </fieldset>
+
+        <fieldset class="c-fieldset">
+          <label class="c-label" for="surname">
+            Regular label <span class="c-label__tag c-label__tag--optional">optional</span>
+          </label>
+          <span class="c-label__metainfo">With additional help text</span>
+          <div class="c-input">
+            <input id="surname" type="text" required>
+          </div>
+        </fieldset>
+
+      </div>
+      <div class="o-grid__unit o-grid__unit--t-1-3">...</div>
+    </div>
+  </div>
+
+
 
   <script id="__bs_script__">
     //<![CDATA[
-      document.write("<script async src='http://HOST:5000/browser-sync/browser-sync-client.js?v=2.24.7'><\/script>".replace("HOST", location.hostname));
+    document.write("<script async src='http://HOST:5000/browser-sync/browser-sync-client.js?v=2.24.7'><\/script>".replace(
+      "HOST", location.hostname));
     //]]>
+
   </script>
 </body>
+
 </html>

--- a/scss/components/_c--form-labels.scss
+++ b/scss/components/_c--form-labels.scss
@@ -5,6 +5,7 @@
 
 // component config
 //
+$label-default-number: $magicNumber;
 $label-font-weight: 700;
 $label-spacing: $spacing--xs;
 $label-tag-font-weight: 400;
@@ -16,6 +17,7 @@ $label-tag-spacing: $spacing--xs / 2;
 %label-element {
   display: block;
   font-weight: $label-font-weight;
+  @include remcalc(line-height, $label-default-number * 1.5);
   @include remcalc(margin-bottom, $label-spacing);
 }
 
@@ -33,8 +35,13 @@ $label-tag-spacing: $spacing--xs / 2;
     @include remcalc(padding-left, $label-tag-spacing);
 
     &--optional {
-      &:before { content: '(' }
-      &:after  { content: ')' }
+      &:before {
+        content: '('
+      }
+
+      &:after {
+        content: ')'
+      }
     }
   }
 
@@ -46,4 +53,6 @@ $label-tag-spacing: $spacing--xs / 2;
 }
 
 label,
-legend { @extend %label-element }
+legend {
+  @extend %label-element
+}

--- a/scss/components/_c--form-labels.scss
+++ b/scss/components/_c--form-labels.scss
@@ -6,6 +6,7 @@
 // component config
 //
 $label-font-weight: 700;
+$label-default-number: $magicNumber;
 $label-spacing: $spacing--xs;
 $label-tag-font-weight: 400;
 $label-tag-color: $monochrome--midGrey;
@@ -16,6 +17,7 @@ $label-tag-spacing: $spacing--xs / 2;
 %label-element {
   display: block;
   font-weight: $label-font-weight;
+  @include remcalc(line-height, $label-default-number * 1.5);
   @include remcalc(margin-bottom, $label-spacing);
 }
 
@@ -33,8 +35,13 @@ $label-tag-spacing: $spacing--xs / 2;
     @include remcalc(padding-left, $label-tag-spacing);
 
     &--optional {
-      &:before { content: '(' }
-      &:after  { content: ')' }
+      &:before {
+        content: '('
+      }
+
+      &:after {
+        content: ')'
+      }
     }
   }
 
@@ -46,4 +53,6 @@ $label-tag-spacing: $spacing--xs / 2;
 }
 
 label,
-legend { @extend %label-element }
+legend {
+  @extend %label-element
+}

--- a/scss/components/_c--form-labels.scss
+++ b/scss/components/_c--form-labels.scss
@@ -5,7 +5,6 @@
 
 // component config
 //
-$label-default-number: $magicNumber;
 $label-font-weight: 700;
 $label-spacing: $spacing--xs;
 $label-tag-font-weight: 400;
@@ -17,7 +16,6 @@ $label-tag-spacing: $spacing--xs / 2;
 %label-element {
   display: block;
   font-weight: $label-font-weight;
-  @include remcalc(line-height, $label-default-number * 1.5);
   @include remcalc(margin-bottom, $label-spacing);
 }
 
@@ -35,13 +33,8 @@ $label-tag-spacing: $spacing--xs / 2;
     @include remcalc(padding-left, $label-tag-spacing);
 
     &--optional {
-      &:before {
-        content: '('
-      }
-
-      &:after {
-        content: ')'
-      }
+      &:before { content: '(' }
+      &:after  { content: ')' }
     }
   }
 
@@ -53,6 +46,4 @@ $label-tag-spacing: $spacing--xs / 2;
 }
 
 label,
-legend {
-  @extend %label-element
-}
+legend { @extend %label-element }

--- a/site/docs/1.0/components/form-input-fields.md
+++ b/site/docs/1.0/components/form-input-fields.md
@@ -60,8 +60,8 @@ Let's look at an example with hint text and an optional flag.
 <fieldset class="c-fieldset">
   <label class="c-label" for="surname">
     Surname: <span class="c-label__tag c-label__tag--optional">optional</span>
+    <span class="c-label__metainfo">With additional help text</span>
   </label>
-  <span class="c-label__metainfo">With additional help text</span>
   <div class="c-input">
     <input id="surname" type="text" required>
   </div>
@@ -74,8 +74,8 @@ Let's look at an example with hint text and an optional flag.
 <fieldset class="c-fieldset">
   <label class="c-label" for="surname">
     Surname: <span class="c-label__tag c-label__tag--optional">optional</span>
+   <span class="c-label__metainfo">With additional help text</span>
   </label>
-  <span class="c-label__metainfo">With additional help text</span>
   <div class="c-input">
     <input id="surname" type="text" required>
   </div>


### PR DESCRIPTION
When labels spill over to a couple lines, the line-height was too tight. This has been brought into line with the line-height of paragraph text now.

Resolves #81